### PR TITLE
feat: display error message in summary

### DIFF
--- a/behaviour.php
+++ b/behaviour.php
@@ -272,12 +272,16 @@ class qbehaviour_questionpy extends question_behaviour {
      * @throws coding_exception
      */
     public function summarise_action(question_attempt_step $step): string {
-        $summary = $this->delegate->summarise_action($step);
         $error = $step->get_qt_var(constants::QT_VAR_ERROR);
+        $summary = $step->has_behaviour_var('finish')
+            ? get_string('attemptfinished', 'question')
+            : $this->delegate->summarise_action($step);
+
         if ($error !== null) {
             $message = get_string('summary_error', 'qbehaviour_questionpy', s($error));
-            $summary .= ' ' . $message;
+            $summary .= " [$message]";
         }
+
         return $summary;
     }
 

--- a/behaviour.php
+++ b/behaviour.php
@@ -262,6 +262,25 @@ class qbehaviour_questionpy extends question_behaviour {
         $step->set_behaviour_var(self::QB_VAR_BEHAVIOUR, $this->delegate->get_name());
     }
 
+    /**
+     * Produce a plain-text summary of what the user did during a step.
+     *
+     * Also view an error message if one was set.
+     *
+     * @param question_attempt_step $step the step in question.
+     * @return string a summary of what was done during that step.
+     * @throws coding_exception
+     */
+    public function summarise_action(question_attempt_step $step): string {
+        $summary = $this->delegate->summarise_action($step);
+        $error = $step->get_qt_var(constants::QT_VAR_ERROR);
+        if ($error !== null) {
+            $message = get_string('summary_error', 'qbehaviour_questionpy', s($error));
+            $summary .= ' ' . $message;
+        }
+        return $summary;
+    }
+
     // The rest we just delegate.
 
     /**
@@ -455,17 +474,6 @@ class qbehaviour_questionpy extends question_behaviour {
      */
     public function classify_response($whichtries = question_attempt::LAST_TRY): array {
         return $this->delegate->classify_response($whichtries);
-    }
-
-
-    /**
-     * Just delegates.
-     *
-     * @param question_attempt_step $step
-     * @return string
-     */
-    public function summarise_action(question_attempt_step $step): string {
-        return $this->delegate->summarise_action($step);
     }
 
     /**

--- a/behaviour.php
+++ b/behaviour.php
@@ -272,11 +272,11 @@ class qbehaviour_questionpy extends question_behaviour {
      * @throws coding_exception
      */
     public function summarise_action(question_attempt_step $step): string {
-        $error = $step->get_qt_var(constants::QT_VAR_ERROR);
         $summary = $step->has_behaviour_var('finish')
             ? get_string('attemptfinished', 'question')
             : $this->delegate->summarise_action($step);
 
+        $error = $step->get_qt_var(constants::QT_VAR_ERROR);
         if ($error !== null) {
             $message = get_string('summary_error', 'qbehaviour_questionpy', s($error));
             $summary .= " [$message]";

--- a/lang/en/qbehaviour_questionpy.php
+++ b/lang/en/qbehaviour_questionpy.php
@@ -24,3 +24,4 @@
 
 $string['pluginname'] = 'QuestionPy Behaviour';
 $string['pluginname_help'] = 'Behaviour for the QuestionPy question type.';
+$string['summary_error'] = 'There was an error while scoring the question. ({$a})';

--- a/version.php
+++ b/version.php
@@ -31,5 +31,5 @@ $plugin->maturity = MATURITY_ALPHA;
 $plugin->release = '0.1';
 
 $plugin->dependencies = [
-    "qtype_questionpy" => 2025100600,
+    "qtype_questionpy" => 2025102300,
 ];


### PR DESCRIPTION
Benötigt: https://github.com/questionpy-org/moodle-qtype_questionpy/pull/229

Mit diesem PR, wird eine Fehlermeldung ausgegeben, wenn beim Scoren etwas schiefgelaufen ist.

Im Falle eines vom QuestionPy-Server zurückgegebenen Fehlers wird der `error_code` angehängt:
<img width="685" height="103" alt="image" src="https://github.com/user-attachments/assets/fc984476-202f-4e05-a670-3625c038c2cd" />
Ansonsten wird die `::class` inklusive des Exception-Codes ausgegeben:
<img width="689" height="106" alt="image" src="https://github.com/user-attachments/assets/05a3a1cf-207a-4e9a-b46a-be6b8820f51c" />
